### PR TITLE
Buffer dropped messages stats - interface change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_pubsub"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Tari development Community"]
 description = "Single publisher with multiple subscribers to topic messages"
 license = "BSD-3-Clause"
@@ -13,5 +13,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_broadcast_channel = { version="^0.1" }
+tari_broadcast_channel = { version="^0.2" }
 futures = { version = "^0.3.1", features=["async-await"] }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pubsub is an abstraction over `tari_broadcast_channel`
 
 ```
     // Create a new channel with a buffer of 10 messages
-    let (mut publisher, subscriber_factory) = pubsub_channel(10);
+    let (mut publisher, subscriber_factory) = pubsub_channel(10, 1);
 
     // Create a struct that we want to use as messages
     #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,10 @@ where
 /// which can produce multiple subscribers for provided topics.
 pub fn pubsub_channel<T: Send + Eq, M: Send + Clone>(
     size: usize,
-) -> (TopicPublisher<T, M>, TopicSubscriptionFactory<T, M>) {
-    let (publisher, subscriber): (TopicPublisher<T, M>, TopicSubscriber<T, M>) = bounded(size);
+    receiver_id: usize,
+) -> (TopicPublisher<T, M>, TopicSubscriptionFactory<T, M>)
+{
+    let (publisher, subscriber): (TopicPublisher<T, M>, TopicSubscriber<T, M>) = bounded(size, receiver_id);
     (publisher, TopicSubscriptionFactory::new(subscriber))
 }
 
@@ -98,7 +100,7 @@ mod test {
 
     #[test]
     fn topic_pub_sub() {
-        let (mut publisher, subscriber_factory) = pubsub_channel(10);
+        let (mut publisher, subscriber_factory) = pubsub_channel(10, 1);
 
         #[derive(Debug, Clone)]
         struct Dummy {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added base channel/subscriber ID for logging identity. Breaking change.

## Motivation and Context
Monitoring is needed for dropped messages in the pub_sub subscription channels. See linked sister PR at https://github.com/tari-project/broadcast_channel/pull/2.

## How Has This Been Tested?
Performed a system-level test on Windows as part of a Tari base node executable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [X] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
