### PR TITLE
Add backwards compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_pubsub"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Tari development Community"]
 description = "Single publisher with multiple subscribers to topic messages"
 license = "BSD-3-Clause"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,14 +83,22 @@ where
 }
 
 /// Create Topic based Pub-Sub channel which returns the Publisher side of the channel and TopicSubscriptionFactory
-/// which can produce multiple subscribers for provided topics.
-pub fn pubsub_channel<T: Send + Eq, M: Send + Clone>(
+/// which can produce multiple subscribers for provided topics. The initial receiver id is required and used to label
+/// the subscribers, which makes debugging simpler.
+pub fn pubsub_channel_with_id<T: Send + Eq, M: Send + Clone>(
     size: usize,
     receiver_id: usize,
 ) -> (TopicPublisher<T, M>, TopicSubscriptionFactory<T, M>)
 {
     let (publisher, subscriber): (TopicPublisher<T, M>, TopicSubscriber<T, M>) = bounded(size, receiver_id);
     (publisher, TopicSubscriptionFactory::new(subscriber))
+}
+
+/// Create a topi-based pub-sub channel with a default receiver id of 1
+pub fn pubsub_channel<T: Send + Eq, M: Send + Clone>(
+    size: usize,
+) -> (TopicPublisher<T, M>, TopicSubscriptionFactory<T, M>) {
+    pubsub_channel_with_id(size, 1)
 }
 
 #[cfg(test)]
@@ -100,7 +108,7 @@ mod test {
 
     #[test]
     fn topic_pub_sub() {
-        let (mut publisher, subscriber_factory) = pubsub_channel(10, 1);
+        let (mut publisher, subscriber_factory) = pubsub_channel(10);
 
         #[derive(Debug, Clone)]
         struct Dummy {


### PR DESCRIPTION
Negates the need for all clients of thislibrary to update their code.

The `pub_sub` function keeps the same signature as v0.1.x by passing a
default id of 1 to the nrely named `pub_sub_with_id`.